### PR TITLE
Remove zip files and www/, resources/ from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ platforms/
 plugins/
 dist/
 openbrews/lib
+*.zip
+resources/
+www/


### PR DESCRIPTION
- The zip file is automatically created by ionic whenever the project is built / uploaded
- The resources and www/ folders are also downloaded by ionic when you are setting up the project
