### PR TITLE
Re-add config, fallback to example config

### DIFF
--- a/openbrews/openbrews.js
+++ b/openbrews/openbrews.js
@@ -17,13 +17,21 @@
 
   .run(function($ionicPlatform, $http, $rootScope) {
     $ionicPlatform.ready(function() {
-      // Read in configuration data
-      /*
+      /* try to get the configuration file */
       $http.get('config.json')
-      .success(function(data, status, headers, config) {
-        $rootScope.config = data;
+      .then(function successCallback(response) {
+        /* if successful, save the data */
+        $rootScope.config = response.data;
+      }, function errorCallback(response) {
+        /* otherwise, try to get the example config instead as a fallback for
+         development to avoid errors */
+         $http.get('example.config.json')
+         .then(function successCallback(response) {
+           $rootScope.config = response.data;
+         }, function errorCallback(response) {
+           console.log("Missing Configuration File 'config.json'");
+         });
       });
-      */
 
       // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
       // for form inputs)


### PR DESCRIPTION
I made it so that if a config.json file isn't found, we fall
back to the example.config.json file. This will keep development
possible without needing API keys, so long as we implement API
calls correctly (verify key exists before trying). It will output
to the console for easy debugging when no config at all is found.
The failure cases for the http.gets are now being handled.

@icyflame Let me know if this is better. I uploaded it to my phone with no config.json file and can verify that all functionality works (as was not the case in #49).
